### PR TITLE
Fix BattleNet deprecations

### DIFF
--- a/nibRealUI/Infobar/Blocks.lua
+++ b/nibRealUI/Infobar/Blocks.lua
@@ -1162,74 +1162,73 @@ function Infobar:CreateBlocks()
                 -- Battle.net Friends
                 for i = 1, _G.BNGetNumFriends() do
                     local accountInfo = _G.C_BattleNet.GetFriendAccountInfo(i)
-                    if accountInfo then
-                        local client = accountInfo.gameAccountInfo.clientProgram ~= "" and accountInfo.gameAccountInfo.clientProgram or nil
+                    if accountInfo and accountInfo.gameAccountInfo.isOnline then
+                        local gameAccountInfo = accountInfo.gameAccountInfo
+                        local client = gameAccountInfo.clientProgram ~= "" and gameAccountInfo.clientProgram or nil
                         local noteText = accountInfo.note
-                        if accountInfo.gameAccountInfo.isOnline then
-                            local characterName = accountInfo.gameAccountInfo.characterName
-                            local class = accountInfo.gameAccountInfo.className or ""
-                            local zoneName = accountInfo.gameAccountInfo.areaName or ""
-                            local level = accountInfo.gameAccountInfo.characterLevel or ""
-                            local gameText = accountInfo.gameAccountInfo.richPresence or ""
+                        local characterName = gameAccountInfo.characterName
+                        local class = gameAccountInfo.className or ""
+                        local zoneName = gameAccountInfo.areaName or ""
+                        local level = gameAccountInfo.characterLevel or ""
+                        local gameText = gameAccountInfo.richPresence or ""
 
-                            local name
-                            if accountInfo.accountName then
-                                name = accountInfo.accountName
-                                characterName = _G.BNet_GetValidatedCharacterName(characterName, accountInfo.battleTag, client)
-                            else
-                                name = _G.UNKNOWN
-                            end
-
-                            if characterName then
-                                if client == _G.BNET_CLIENT_WOW and _G.CanCooperateWithGameAccount(accountInfo) then
-                                    name = nameFormat:format(bnetFriendColor, name, _G.CUSTOM_CLASS_COLORS[ClassLookup[class]].colorStr, characterName)
-                                else
-                                    if ( _G.ENABLE_COLORBLIND_MODE == "1" ) then
-                                        name = nameFormat:format(bnetFriendColor, name, "ff7b8489", characterName.._G.CANNOT_COOPERATE_LABEL)
-                                    else
-                                        name = nameFormat:format(bnetFriendColor, name, "ff7b8489", characterName)
-                                    end
-                                end
-                            end
-
-                            if accountInfo.isAFK or accountInfo.gameAccountInfo.isGameAFK then
-                                name = PlayerStatus[1] .. name
-                            elseif accountInfo.isDND or accountInfo.gameAccountInfo.isGameBusy then
-                                name = PlayerStatus[2] .. name
-                            end
-                            name = _G.BNet_GetClientEmbeddedTexture(client, 14, 14, 0, 0) .. name
-
-                            -- Difficulty color levels
-                            local lvl = tonumber(level)
-                            if lvl then
-                                local color = _G.ConvertRGBtoColorString(_G.GetQuestDifficultyColor(level))
-                                level = ("%s%d|r"):format(color, level)
-                            end
-
-                            local status
-                            if client == _G.BNET_CLIENT_WOW then
-                                if ( not zoneName or zoneName == "" ) then
-                                    status = _G.UNKNOWN
-                                else
-                                    status = zoneName
-                                end
-                            else
-                                status = gameText
-                            end
-
-                            if noteText == "" then noteText = nil end
-
-
-                            tinsert(friendsData, {
-                                id = i,
-                                info = {
-                                    name, level, status, noteText
-                                },
-                                meta = {
-                                    i, lvl, {characterName, accountInfo.accountName, accountInfo.bnetAccountID}
-                                }
-                            })
+                        local name
+                        if accountInfo.accountName then
+                            name = accountInfo.accountName
+                            characterName = _G.BNet_GetValidatedCharacterName(characterName, accountInfo.battleTag, client)
+                        else
+                            name = _G.UNKNOWN
                         end
+
+                        if characterName then
+                            if client == _G.BNET_CLIENT_WOW and _G.CanCooperateWithGameAccount(accountInfo) then
+                                name = nameFormat:format(bnetFriendColor, name, _G.CUSTOM_CLASS_COLORS[ClassLookup[class]].colorStr, characterName)
+                            else
+                                if ( _G.ENABLE_COLORBLIND_MODE == "1" ) then
+                                    name = nameFormat:format(bnetFriendColor, name, "ff7b8489", characterName.._G.CANNOT_COOPERATE_LABEL)
+                                else
+                                    name = nameFormat:format(bnetFriendColor, name, "ff7b8489", characterName)
+                                end
+                            end
+                        end
+
+                        if accountInfo.isAFK or gameAccountInfo.isGameAFK then
+                            name = PlayerStatus[1] .. name
+                        elseif accountInfo.isDND or gameAccountInfo.isGameBusy then
+                            name = PlayerStatus[2] .. name
+                        end
+                        name = _G.BNet_GetClientEmbeddedTexture(client, 14, 14, 0, 0) .. name
+
+                        -- Difficulty color levels
+                        local lvl = tonumber(level)
+                        if lvl then
+                            local color = _G.ConvertRGBtoColorString(_G.GetQuestDifficultyColor(level))
+                            level = ("%s%d|r"):format(color, level)
+                        end
+
+                        local status
+                        if client == _G.BNET_CLIENT_WOW then
+                            if ( not zoneName or zoneName == "" ) then
+                                status = _G.UNKNOWN
+                            else
+                                status = zoneName
+                            end
+                        else
+                            status = gameText
+                        end
+
+                        if noteText == "" then noteText = nil end
+
+
+                        tinsert(friendsData, {
+                            id = i,
+                            info = {
+                                name, level, status, noteText
+                            },
+                            meta = {
+                                i, lvl, {characterName, accountInfo.accountName, accountInfo.bnetAccountID}
+                            }
+                        })
                     end
                 end
 


### PR DESCRIPTION
### What does this implement/fix? Explain your changes ###

Blizzard deprecated / changed some BattleNet related functions in 8.2.5.
``CanCooperateWithGameAccount`` now takes the whole BattleNet account info as its argument instead of just the accountID.
Also the BC layer implementation of ``BNGetGameAccountInfo`` seems to return empty results.

### Does this close any currently open issues? ###

No.

### Any relevant logs, error output, etc? ###

x1  FrameXML\FriendsFrame.lua:2287: attempt to index local 'accountInfo' (a number value)
Stack: FrameXML\FriendsFrame.lua:2287: in function 'CanCooperateWithGameAccount'
nibRealUI\Infobar\Blocks.lua:1249: in function 'OnEnter'
nibRealUI\Infobar\Bar.lua:69: in function <nibRealUI\Infobar\Bar.lua:54>
Time: 2019/09/27 23:24:09 Index: 1/1
RealUI Version: 2.1.0
Locals:
accountInfo = 48
(*temporary) = nil
(*temporary) = nil
(*temporary) = "attempt to index local 'accountInfo' (a number value)"
playerFactionGroup = "Alliance"

### Any other comments? ###

