### PR TITLE
Fix some races having cut off options in barber shop

### DIFF
--- a/RealUI_Skins/RealUI_Skins.lua
+++ b/RealUI_Skins/RealUI_Skins.lua
@@ -235,6 +235,7 @@ function private.OnLoad()
         -- BarberShopFrame.ResetButton - Anchored to CancelButton
         BarberShopFrame.AcceptButton:SetPoint("BOTTOMRIGHT", CharCustomizeFrame, -30, 15)
         -- BarberShopFrame.PriceFrame - Anchored to AcceptButton
+        CharCustomizeFrame.Options.spacing = 5
     end)
 
     -- Disable user selected addon skins


### PR DESCRIPTION
### What does this implement/fix? Explain your changes ###

Fixes cut off options on some races. Tested on 1920x1080 with Undead, Night elf (longest options list) and also Orc, Blood elf and Worgen.
`spacing = 6` is also possible. On higher values the undead eye color pop up is unusable.

### Does this close any currently open issues? ###

#70

### Any relevant logs, error output, etc? ###



### Any other comments? ###

