### PR TITLE
Ensure GetAddOnMetadata is prepended by C_AddOns

### DIFF
--- a/RealUI_Bugs/Init.lua
+++ b/RealUI_Bugs/Init.lua
@@ -8,7 +8,7 @@ end
 
 -- Disable !BugGrabber displays
 for i = 1, _G.GetNumAddOns() do
-    local meta = _G.GetAddOnMetadata(i, "X-BugGrabber-Display")
+    local meta = _G.C_AddOns.GetAddOnMetadata(i, "X-BugGrabber-Display")
     if meta then
         local _, _, _, enabled = _G.GetAddOnInfo(i)
         if enabled then

--- a/RealUI_Bugs/Libs/!BugGrabber/BugGrabber.lua
+++ b/RealUI_Bugs/Libs/!BugGrabber/BugGrabber.lua
@@ -60,7 +60,7 @@ local L = {
 -- Should implement :FormatError(errorTable).
 local displayObjectName = nil
 for i = 1, GetNumAddOns() do
-	local meta = GetAddOnMetadata(i, "X-BugGrabber-Display")
+	local meta = C_AddOns.GetAddOnMetadata(i, "X-BugGrabber-Display")
 	if meta then
 		local _, _, _, enabled = GetAddOnInfo(i)
 		if enabled then
@@ -191,9 +191,9 @@ do
 		end
 		-- Then see if we can get some addon metadata
 		if not found and IsAddOnLoaded(object) then
-			found = GetAddOnMetadata(object, "X-Curse-Packaged-Version")
+			found = C_AddOns.GetAddOnMetadata(object, "X-Curse-Packaged-Version")
 			if not found then
-				found = GetAddOnMetadata(object, "Version")
+				found = C_AddOns.GetAddOnMetadata(object, "Version")
 			end
 		end
 		-- Perhaps it's a global object?

--- a/RealUI_Bugs/RealUI_Bugs.lua
+++ b/RealUI_Bugs/RealUI_Bugs.lua
@@ -302,12 +302,12 @@ function errorFrame.ADDON_LOADED(addon)
     end
 
     if versions[addon] then
-        local version = _G.GetAddOnMetadata(addon, "Version")
+        local version = _G.C_AddOns.GetAddOnMetadata(addon, "Version")
         versions[addon] = versions[addon]..version
     end
 
     if addon == "nibRealUI" then
-        coreVersion = _G.GetAddOnMetadata(addon, "Version")
+        coreVersion = _G.C_AddOns.GetAddOnMetadata(addon, "Version")
         coreVersion = "RealUI_Core-"..coreVersion
         _G.RealUI_Storage.nibRealUI = {}
         _G.RealUI_Storage.nibRealUI.nibRealUIDB = _G.nibRealUIDB

--- a/nibRealUI/Core.lua
+++ b/nibRealUI/Core.lua
@@ -11,7 +11,7 @@ local debug = RealUI.GetDebug("Core")
 
 local LDS = _G.LibStub("LibDualSpec-1.0")
 
-local version = _G.GetAddOnMetadata(ADDON_NAME, "Version")
+local version = _G.C_AddOns.GetAddOnMetadata(ADDON_NAME, "Version")
 RealUI.verinfo = {strsplit(".", version)}
 for i = 1, 3 do
     RealUI.verinfo[i] = tonumber(RealUI.verinfo[i])

--- a/nibRealUI/Libs/Fixes/InspectFix.lua
+++ b/nibRealUI/Libs/Fixes/InspectFix.lua
@@ -9,7 +9,7 @@ local InspectGuildFrame_Update = nil
 local loaded = false
 local debugging = false
 local allowDetarget = false   	-- allow window to remain open when target is not inspectable (experimental)
-local serverTimeout = 1		-- timeout for INSPECT_READY response to assume server dropped it 
+local serverTimeout = 1		-- timeout for INSPECT_READY response to assume server dropped it
 
 local function debug(msg)
   if debugging then
@@ -23,7 +23,7 @@ local function inspectable(unit)
   return unit and UnitExists(unit) and UnitIsConnected(unit) and CanInspect(unit)
 end
 
-local function inspectfilter(self, event, ...) 
+local function inspectfilter(self, event, ...)
   --myprint(event,...)
   if loaded then
     local unit = InspectFrame.unit
@@ -32,14 +32,14 @@ local function inspectfilter(self, event, ...)
        return true
     elseif event == nil and not inspectable then
        return false
-    elseif event == "PLAYER_TARGET_CHANGED" then -- suppress close on change 
+    elseif event == "PLAYER_TARGET_CHANGED" then -- suppress close on change
        if inspectable and InspectFix.UserInspecting() then
           InspectFrame_UnitChanged(InspectFrame);
        end
        return false
     end
-    if inspectable and lastUINITime and not lastUIIRTime and 
-       InspectFix.UserInspecting() and 
+    if inspectable and lastUINITime and not lastUIIRTime and
+       InspectFix.UserInspecting() and
        (lastUINITime + serverTimeout) < GetTime() then
        debug("Re-issuing dropped notify")
        InspectFrame_UnitChanged(InspectFrame);
@@ -73,7 +73,7 @@ local inspect_item = {}
 local inspect_unit = nil
 local inspect_guid = nil
 local buttonhooked = {}
-local function pdfclick(self)  
+local function pdfclick(self)
    -- fix modified click on item buttons
    local id = self and self:GetID()
    local unit = InspectFrame.unit
@@ -140,7 +140,7 @@ end
 
 function InspectFix:GetID() return self.val end
 InspectFix.val = INVSLOT_FIRST_EQUIPPED
-function InspectFix:Update() 
+function InspectFix:Update()
  for slot = INVSLOT_FIRST_EQUIPPED, INVSLOT_LAST_EQUIPPED do
    InspectFix.val = slot
    pdfupdate(InspectFix)
@@ -227,7 +227,7 @@ local function inspectunit(unit)
   if not inspectable(unit) then return end
   -- NotifyInspect blocking in this addon and others is controlled by visibility of InspectFrame
   -- When the user requests an inspect we need to immediately show that frame to start that blocking
-  -- and ensure the Notify issued by InspectFrame isn't squashed by a subsequent stealth inspect, 
+  -- and ensure the Notify issued by InspectFrame isn't squashed by a subsequent stealth inspect,
   -- which would effectively cancel the user's manual inspect, causing the frame to never be shown
   ShowUIPanel(InspectFrame)
   -- issue a (duplicate) NotifyInspect with the frame open, to engage our retry and be extra-sure
@@ -367,10 +367,10 @@ InspectFix:RegisterEvent("INSPECT_READY")
 function InspectFix:Load()
   InspectFix:tryhook()
   loaded = true
-  local revstr 
-  revstr = GetAddOnMetadata("InspectFix", "X-Curse-Packaged-Version")
+  local revstr
+  revstr = C_AddOns.GetAddOnMetadata("InspectFix", "X-Curse-Packaged-Version")
   if not revstr then
-  revstr = GetAddOnMetadata("InspectFix", "Version")
+  revstr = C_AddOns.GetAddOnMetadata("InspectFix", "Version")
   end
   if not revstr or string.find(revstr, "@") then
     revstr = "r"..tostring(revision)


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

### What does this implement/fix? Explain your changes ###
https://wowpedia.fandom.com/wiki/Patch_10.1.0/API_changes documents that [C_AddOns.GetAddOnMetadata](https://wowpedia.fandom.com/wiki/API_C_AddOns.GetAddOnMetadata) was added, and [GetAddOnMetadata](https://wowpedia.fandom.com/wiki/API_GetAddOnMetadata) was removed.

### Does this close any currently open issues? ###
Yarp

Link to the issues here
https://github.com/RealUI/RealUI/issues/85

### Any relevant logs, error output, etc? ###

Can't really miss this one running Real UI at all.

### Any other comments? ###
First contribution; mostly just got the fix concept from Discord
